### PR TITLE
Updated reserved screen to show latest desk name

### DIFF
--- a/templates/kit_reserved.html
+++ b/templates/kit_reserved.html
@@ -14,7 +14,7 @@
                 <div class="detailBoxHolder">
                     <div class="detailBox">
                         <div class="desk">
-                            <h1>DESK A</h1>
+                            <h1>{{session.tableName}}</h1>
                         </div>
                         <div class="availability">
                             <h1>RESERVED</h1>


### PR DESCRIPTION
Updated the Desk Kit reserved screen to include the name assigned to that
desk in order to assist the user in identifying their reserved desk using the
monitor provided.